### PR TITLE
WSC-850: Migrate `GoogleSignIn` to 7.0.0

### DIFF
--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -1,15 +1,15 @@
 
   Pod::Spec.new do |s|
     s.name = 'CodetrixStudioCapacitorGoogleAuth'
-    s.version = '0.0.1'
+    s.version = '3.3.5'
     s.summary = 'Google Auth plugin for capacitor.'
     s.license = 'MIT'
-    s.homepage = 'https://github.com/CodetrixStudio/CapacitorGoogleAuth.git'
-    s.author = 'CodetrixStudio'
-    s.source = { :git => 'https://github.com/CodetrixStudio/CapacitorGoogleAuth.git', :tag => s.version.to_s }
+    s.homepage = 'https://github.com/metova/CapacitorGoogleAuth.git'
+    s.author = 'CodetrixStudio', 'Metova'
+    s.source = { :git => 'https://github.com/metova/CapacitorGoogleAuth.git', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn', '~> 6.2.4'
+    s.dependency 'GoogleSignIn', '~> 7.0.0'
     s.static_framework = true
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -8,7 +8,7 @@ target 'Plugin' do
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 
-  pod 'GoogleSignIn', '~> 6.0.1'
+  pod 'GoogleSignIn', '~> 7.0.0'
 
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,25 +1,26 @@
 PODS:
-  - AppAuth (1.4.0):
-    - AppAuth/Core (= 1.4.0)
-    - AppAuth/ExternalUserAgent (= 1.4.0)
-  - AppAuth/Core (1.4.0)
-  - AppAuth/ExternalUserAgent (1.4.0)
-  - Capacitor (3.0.1):
+  - AppAuth (1.6.2):
+    - AppAuth/Core (= 1.6.2)
+    - AppAuth/ExternalUserAgent (= 1.6.2)
+  - AppAuth/Core (1.6.2)
+  - AppAuth/ExternalUserAgent (1.6.2):
+    - AppAuth/Core
+  - Capacitor (5.0.4):
     - CapacitorCordova
-  - CapacitorCordova (3.0.1)
-  - GoogleSignIn (6.0.1):
-    - AppAuth (~> 1.4)
-    - GTMAppAuth (~> 1.0)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - GTMAppAuth (1.2.2):
-    - AppAuth/Core (~> 1.4)
-    - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.6.1)
+  - CapacitorCordova (5.0.4)
+  - GoogleSignIn (7.0.0):
+    - AppAuth (~> 1.5)
+    - GTMAppAuth (< 3.0, >= 1.3)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
+  - GTMAppAuth (2.0.0):
+    - AppAuth/Core (~> 1.6)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.5)
+  - GTMSessionFetcher/Core (3.1.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - GoogleSignIn (~> 6.0.1)
+  - GoogleSignIn (~> 7.0.0)
 
 SPEC REPOS:
   trunk:
@@ -35,13 +36,13 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  Capacitor: 92088387144015b95e369bd7840e8ef28b8fe9f3
-  CapacitorCordova: 624ae0d33d61b554eda6823da8ea6c3e5170f646
-  GoogleSignIn: 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
-  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
+  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
+  Capacitor: d3d4463573438b9fa65326d1f3549da6f4c21634
+  CapacitorCordova: b1fe6bf1f36974a8e4a9044b342d22d49c0996d6
+  GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
+  GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
+  GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
 
-PODFILE CHECKSUM: 0f3f70de2469d6ef87a4f55c3a96868777b79b2e
+PODFILE CHECKSUM: 3ab1a4f97cba94ec738c8fa36f1ebdf26321f7a1
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.13.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "3.3.4",
+  "name": "@metova/capacitor-google-auth",
+  "version": "3.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@codetrix-studio/capacitor-google-auth",
-      "version": "3.3.4",
+      "name": "@metova/capacitor-google-auth",
+      "version": "3.3.5",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^5.0.4",
@@ -16,6 +16,7 @@
         "@ionic/prettier-config": "^2.0.0",
         "@types/gapi": "0.0.42",
         "@types/gapi.auth2": "0.0.56",
+        "@types/node": "^20.9.0",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4"
       },
@@ -228,9 +229,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.7.3",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/slice-ansi": {
       "version": "4.0.0",
@@ -826,9 +831,10 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -973,6 +979,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "3.3.4",
+  "name": "@metova/capacitor-google-auth",
+  "version": "3.3.5",
   "description": "Google Auth plugin for capacitor.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -13,6 +13,12 @@
     "test": "echo \"no test specified\""
   },
   "author": "CodetrixStudio",
+  "contributors": [
+    {
+      "name": "Metova",
+      "url": "https://github.com/metova"
+    }
+  ],
   "license": "MIT",
   "devDependencies": {
     "@capacitor/android": "^5.0.4",
@@ -22,6 +28,7 @@
     "@ionic/prettier-config": "^2.0.0",
     "@types/gapi": "0.0.42",
     "@types/gapi.auth2": "0.0.56",
+    "@types/node": "^20.9.0",
     "prettier": "^2.7.1",
     "typescript": "^4.7.4"
   },
@@ -58,10 +65,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/CodetrixStudio/CapacitorGoogleAuth"
+    "url": "https://github.com/metova/CapacitorGoogleAuth"
   },
   "bugs": {
-    "url": "https://github.com/CodetrixStudio/CapacitorGoogleAuth/issues"
+    "url": "https://github.com/metova/CapacitorGoogleAuth/issues"
   },
   "prettier": "@ionic/prettier-config"
 }


### PR DESCRIPTION
Migrated the `GoogleSignIn` SDK from `6.2.4` to `7.0.0`: https://developers.google.com/identity/sign-in/ios/quick-migration-guide